### PR TITLE
Start / End Date Interaction, Default Gig Duration

### DIFF
--- a/server/migrations/20170420162000-update-profile.js
+++ b/server/migrations/20170420162000-update-profile.js
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright (C) 2017 Phoenix Bright Software, LLC
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+"use strict";
+
+module.exports = {
+    up: function(queryInterface, Sequelize) {
+        return queryInterface.addColumn(
+            "profiles",
+            "leadTime", {
+                type: Sequelize.INTEGER,
+                allowNull: true
+            }
+        );
+    },
+
+    down: function(queryInterface, Sequelize) { // eslint-disable-line
+        return queryInterface.removeColumn("profiles", "leadTime");
+    }
+};

--- a/server/models/profile.js
+++ b/server/models/profile.js
@@ -36,7 +36,8 @@ module.exports = function(sequelize, DataTypes) {
                 this.setDataValue("homeBasePlace", place.toString());
             }
         },
-        defaultDuration: { type: DataTypes.INTEGER, allowNull: true }
+        defaultDuration: { type: DataTypes.INTEGER, allowNull: true },
+        leadTime: { type: DataTypes.INTEGER, allowNull: true }
     }, {
         classMethods: {
             

--- a/server/plugins/settingsPlugin.js
+++ b/server/plugins/settingsPlugin.js
@@ -46,16 +46,13 @@ var settingsPlugin = {
 
                 models.profile.findOne(options).then(function(profile) {
                     if (profile) {
-                        var settings = {
-                            homeBasePlace: profile.homeBasePlace
-                        };
+                        var settings = profile.get({ plain: true });
                         return reply(settings);
                     } else {
                         return reply(Boom.unauthorized("Invalid Session"));
                     }
                 }).catch(function(err) {
-                    console.log(err);
-                    return reply(Boom.badImplementation());
+                    return reply(Boom.badImplementation(err));
                 });
             }
         });
@@ -70,7 +67,8 @@ var settingsPlugin = {
                 validate: {
                     payload: {
                         homeBasePlace: Joi.object().optional().allow(null).default(null),
-                        defaultDuration: Joi.number().integer().optional().allow(null)
+                        defaultDuration: Joi.number().integer().optional().allow(null),
+                        leadTime: Joi.number().integer().optional().allow(null)
                     }
                 }
             },
@@ -99,8 +97,7 @@ var settingsPlugin = {
                 }).then(function() {
                     return reply();
                 }).catch(function(err) {
-                    console.log(err);
-                    return reply(Boom.badImplementation());
+                    return reply(Boom.badImplementation(err));
                 });
             }
         });

--- a/www_src/js/controllers/gigEdit.js
+++ b/www_src/js/controllers/gigEdit.js
@@ -19,8 +19,8 @@
 'use strict';
 
 angular.module('GigKeeper').controller('GigEditController', [
-    '$scope', '$uibModalInstance', 'contractors', 'Tag', 'Gig', 'gig', 'UrlBuilder', 'BlockingPromiseManager',
-    function($scope, $uibModalInstance, contractors, Tag, Gig, gig, UrlBuilder, BlockingPromiseManager) {
+    '$rootScope', '$scope', '$uibModalInstance', 'contractors', 'Tag', 'Gig', 'gig', 'UrlBuilder', 'BlockingPromiseManager',
+    function($rootScope, $scope, $uibModalInstance, contractors, Tag, Gig, gig, UrlBuilder, BlockingPromiseManager) {
 
         $scope.contractors = contractors;
 
@@ -62,6 +62,25 @@ angular.module('GigKeeper').controller('GigEditController', [
             tags: gig.tags,
             notes: gig.notes
         };
+
+        $scope.$watch('form.startDate', function(newValue, oldValue) {
+            if (newValue != oldValue && newValue) {
+                if ($scope.form.endDate < $scope.form.startDate) {
+                    $scope.form.endDate = $scope.form.startDate;
+                }
+                if ($rootScope.profile.profile.defaultDuration > 0) {
+                    $scope.form.endDate = new Date(newValue.getTime() + ($rootScope.profile.profile.defaultDuration * 60 * 1000));
+                }
+            }
+        });
+
+        $scope.$watch('form.endDate', function(newValue, oldValue) {
+            if (newValue != oldValue && newValue) {
+                if ($scope.form.endDate < $scope.form.startDate) {
+                    $scope.form.startDate = $scope.form.endDate;
+                }
+            }
+        });
 
         /**
          * Estimate the distance to the specified location

--- a/www_src/js/controllers/settings.js
+++ b/www_src/js/controllers/settings.js
@@ -22,11 +22,16 @@ angular.module('GigKeeper').controller('settings', [
     '$scope', 'Settings', 'settings', 'BlockingPromiseManager',
     function($scope, Settings, settings, BlockingPromiseManager) {
 
-        $scope.homeBaseOptions = {
-            placeIdOnly: true
+        $scope.durationOptions = {
+            decimals: 0,
+            format: '0 minutes',
+            min: 0,
+            defaultValue: 0
         };
 
         $scope.form = {
+            defaultDuration: settings.defaultDuration || 0,
+            leadTime: settings.leadTime || 0,
             homeBasePlace: settings.homeBasePlace
         };
 
@@ -37,6 +42,8 @@ angular.module('GigKeeper').controller('settings', [
                 button.button('loading');
 
                 var payload = {
+                    defaultDuration: $scope.form.defaultDuration,
+                    leadTime: $scope.form.leadTime,
                     homeBasePlace: $scope.form.homeBasePlace
                 };
 

--- a/www_src/template/settings.html
+++ b/www_src/template/settings.html
@@ -12,6 +12,43 @@
             <div class="col-md-6">
                 <div class="panel panel-default">
                     <div class="panel-heading">
+                        <h3 class="panel-title">Gig Settings</h3>
+                    </div>
+                    <div class="panel-body">
+
+                        <div class="form-group">
+                            <label for="profile_homeBase">Default Duration</label>
+                            <div>
+                                <input type="text" 
+                                    id="profile_defaultDuration" 
+                                    name="defaultDuration" 
+                                    kendo-numeric-text-box
+                                    options="durationOptions"
+                                    ng-model="form.defaultDuration" />
+                            </div>
+                            <p class="help-block">The end date will automatically be set
+                                to the start date plus the default duration in minutes.</p>
+                        </div>
+
+                        <div class="form-group">
+                            <label for="profile_homeBase">Lead Time</label>
+                            <div>
+                                <input type="text" 
+                                    id="profile_leadTime" 
+                                    name="leadTime" 
+                                    kendo-numeric-text-box
+                                    options="durationOptions"
+                                    ng-model="form.leadTime" />
+                            </div>
+                            <p class="help-block">How many minutes prior to the gig start time do you wish to arrive?
+                                This will be used in calculating a suggested departure time.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="panel panel-default">
+                    <div class="panel-heading">
                         <h3 class="panel-title">Location Settings</h3>
                     </div>
                     <div class="panel-body">
@@ -22,10 +59,12 @@
                                    name="homeBasePlace" 
                                    class="form-control"
                                    g-places-autocomplete 
-                                   options="homeBaseOptions"
                                    data-force-selection="true"
                                    ng-model="form.homeBasePlace"
                                    autocomplete="off" />
+                            <p class="help-block">This is your default home base. By default,
+                                all distance / travel time estimations are made from this location.</p>
+                            </p>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Added support for a default gig duration setting that updates the end date to the start date plus the default duration as the start date is changed. Also updated the gig edit form to adjust the start / end dates if one is set past the other.

Also added a lead time profile setting for future use.

Includes a migration.