### PR TITLE
EB Deploy Task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,8 @@ var gulp = require("gulp"),
     config = require("./config/config.js"),
     fs = require("fs"),
     zip = require("gulp-zip"),
-    clean = require("gulp-clean");
+    clean = require("gulp-clean"),
+    gulpEbDeploy = require('gulp-elasticbeanstalk-deploy');
 
 var globs = {
         config: "config/config.json",
@@ -224,6 +225,32 @@ gulp.task("dist:build", ["build", "dist:clean"], function() {
         "!config/config.json" ], { base: "./" })
         .pipe(zip(filename))
         .pipe(gulp.dest("dist"));
+});
+
+gulp.task('deploy', function() {
+    return gulp.src([ ".ebextensions",
+        ".bowerrc",
+        "bower.json",
+        "config/**/*",
+        "LICENSE.md",
+        "main.js",
+        "package.json",
+        "README.md",
+        "server/**/*",
+        "www/**/*",
+        "!www/bower_components/**/*",
+        "!config/config.json" ], { base: "./" })
+    .pipe(gulpEbDeploy({
+        name: 'GigKeeper',
+        timestamp: true,
+        waitForDeploy: true,
+        amazon: {
+            region: 'us-west-2',
+            bucket: 'elasticbeanstalk-us-west-2-008453750068',
+            applicationName: 'GIgKeeper',
+            environmentName: 'gigkeeper-env'
+        }
+    }))
 });
 
 /*** Server tasks ***/

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "gulp-clean": "^0.3.2",
     "gulp-clean-css": "^3.0.4",
     "gulp-concat": "^2.6.1",
+    "gulp-elasticbeanstalk-deploy": "^1.1.0",
     "gulp-eslint": "^3.0.1",
     "gulp-imagemin": "^3.2.0",
     "gulp-include-2": "^2.3.1",


### PR DESCRIPTION
Added gulp task to deploy to elastic beanstalk. Could possibly use so tweaking to externalize things like region and bucket and environment names. Can these be taken from the .elasticbeanstalk folder that gets ignored by git?