### PR TITLE
HTTPS Support

### DIFF
--- a/.ebextensions/00_nginx_https_rw.config
+++ b/.ebextensions/00_nginx_https_rw.config
@@ -1,0 +1,13 @@
+# Add http to https rewrite in nginx config
+# http://stackoverflow.com/questions/24297375/how-to-get-elastic-beanstalk-nginx-backed-proxy-server-to-auto-redirect-from-htt
+
+files:
+  "/etc/nginx/conf.d/000_my_config.conf":
+    mode: "000755"
+    owner: root
+    owner: root
+    content: |
+      server {
+          listen 8080;
+          return 301 https://$host$request_uri;
+      }

--- a/.ebextensions/AWS_Single_LetsEncrypt.config
+++ b/.ebextensions/AWS_Single_LetsEncrypt.config
@@ -1,0 +1,61 @@
+Resources:
+  sslSecurityGroupIngress: 
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: {"Fn::GetAtt" : ["AWSEBSecurityGroup", "GroupId"]}
+      IpProtocol: tcp
+      ToPort: 443
+      FromPort: 443
+      CidrIp: 0.0.0.0/0
+
+files:
+      
+  # The Nginx config forces https
+  /etc/nginx/conf.d/https_custom.pre:
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      # HTTPS server
+      server {
+        listen       443 default ssl;
+        server_name  localhost;
+        error_page  497 https://$host$request_uri;
+        
+        ssl_certificate      /etc/letsencrypt/live/ebcert/fullchain.pem;
+        ssl_certificate_key  /etc/letsencrypt/live/ebcert/privkey.pem;
+        ssl_session_timeout  5m;
+        ssl_protocols  TLSv1.1 TLSv1.2;
+        ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+        ssl_prefer_server_ciphers   on;
+        if ($ssl_protocol = "") {
+          rewrite ^ https://$host$request_uri? permanent;
+        }
+        location ~ ^/(lib/|img/) {
+          root /var/app/current/public;
+          access_log off;
+        }
+        location / {
+            proxy_pass  http://nodejs;
+            proxy_set_header   Connection "";
+            proxy_http_version 1.1;
+            proxy_set_header        Host            $host;
+            proxy_set_header        X-Real-IP       $remote_addr;
+            proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header        Upgrade         $http_upgrade;
+            proxy_set_header        Connection      "upgrade";
+        }
+      }
+packages: 
+  yum:
+    epel-release: [] 
+
+container_commands:
+  10_installcertbot:
+    command: "wget https://dl.eff.org/certbot-auto;chmod a+x certbot-auto"
+  20_getcert:
+    command: "sudo ./certbot-auto certonly --debug --non-interactive --email swamsley@gmail.com --agree-tos --standalone --domains ${certdomain} --keep-until-expiring --pre-hook \"service nginx stop\""
+  30_link:
+    command: "ln -sf /etc/letsencrypt/live/${certdomain} /etc/letsencrypt/live/ebcert"
+  40_config:
+    command: "mv /etc/nginx/conf.d/https_custom.pre /etc/nginx/conf.d/https_custom.conf"

--- a/config/config.js
+++ b/config/config.js
@@ -55,8 +55,7 @@ module.exports = {
         }
     },
     api: {
-        host: process.env.API_HOST || configJson.api.host || "localhost",
-        port: process.env.API_PORT || configJson.api.port || 8000
+        base: process.env.API_BASE || configJson.api.base || "http://localhost:8000"
     },
     db: {
         host: dbconfig[env].host,

--- a/config/config.json.sample
+++ b/config/config.json.sample
@@ -10,8 +10,7 @@
         }
     },
     "api": {
-        "host": "localhost",
-        "port": 8000
+        "base": "http://localhost:8000"
     },
     "db": {
         "host": "localhost",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -210,7 +210,7 @@ gulp.task("dist:build", ["build", "dist:clean"], function() {
 
     var filename = "gigkeeper.zip";
 
-    gulp.src([ ".ebextensions",
+    gulp.src([ ".ebextensions/**/*",
         ".bowerrc",
         "bower.json",
         "config/**/*",
@@ -227,7 +227,7 @@ gulp.task("dist:build", ["build", "dist:clean"], function() {
 });
 
 gulp.task('deploy', function() {
-    return gulp.src([ ".ebextensions",
+    return gulp.src([ ".ebextensions/**/*",
         ".bowerrc",
         "bower.json",
         "config/**/*",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -115,8 +115,7 @@ gulp.task("config", function() {
         appConfigString = "var appConfig = ";
 
     appConfig.api = {
-        host: config.api.host,
-        port: config.api.port
+        base: config.api.base
     };
 
     appConfigString += JSON.stringify(appConfig) + ";";

--- a/www_src/js/factory/urlBuilder.js
+++ b/www_src/js/factory/urlBuilder.js
@@ -24,7 +24,7 @@ angular.module('GigKeeper').factory('UrlBuilder', [
             build: function (relativeUrl) {
                 var apiConfig = window.appConfig.api;
 
-                return 'http://' + apiConfig.host + ':' + apiConfig.port + relativeUrl;
+                return apiConfig.base + relativeUrl;
             }
         };
     }


### PR DESCRIPTION
EB configuration to host the web server under SSL and redirect HTTP to HTTPS. Also adjusted apiConfig.js and UrlBuilder to use a base URL instead of individual host and port so it picks up the protocol.

Help from:

https://bluefletch.com/blog/domain-agnostic-letsencrypt-ssl-config-for-elastic-beanstalk-single-instances/

http://stackoverflow.com/questions/24297375/how-to-get-elastic-beanstalk-nginx-backed-proxy-server-to-auto-redirect-from-htt/28271106#28271106